### PR TITLE
fix: Clear analysis results when a new chart is generated

### DIFF
--- a/src/components/StockChartAnalyzer.js
+++ b/src/components/StockChartAnalyzer.js
@@ -137,6 +137,15 @@ function StockChartAnalyzer() {
         setStockSymbol(stock.symbol);
         setShowSuggestions(false);
         setSelectedSuggestionIndex(-1);
+        setPrediction(null);
+        setPatternDetected(null);
+        setConfidence(null);
+        setRecommendation(null);
+        setEntryExit(null);
+        setTimeEstimate(null);
+        setBreakoutTiming(null);
+        setKeyLevels(null);
+        setLongTermAssessment(null);
         fetchAllData(stock.symbol, selectedTimeRange);
     };
 


### PR DESCRIPTION
This commit fixes an issue where the previously analyzed chart results were not disappearing when a new chart was generated. This was causing confusion for you. The fix involves clearing the analysis results when a new stock is selected or the time range is changed.