### PR TITLE
fix: Remove mock data fallback

### DIFF
--- a/src/hooks/useStockData.js
+++ b/src/hooks/useStockData.js
@@ -19,6 +19,7 @@ export const useStockData = () => {
         } catch (error) {
             setError(error.message);
             console.error('Stock data fetch error:', error);
+            setStockData(null);
         } finally {
             setLoading(false);
         }


### PR DESCRIPTION
This commit fixes an issue where the application was falling back to mock data when the API call failed. This was causing confusion for you. The fix involves removing the mock data fallback and instead displaying an error message when the API call fails.