### PR TITLE
fix: Fix prediction accuracy calculation

### DIFF
--- a/src/utils/analysis.js
+++ b/src/utils/analysis.js
@@ -223,5 +223,5 @@ const findPeaksAndTroughs = (data, isPeak = true) => {
       }
     }
 
-    return totalPredictions > 0 ? (correctPredictions / totalPredictions) * 100 : 99;
+    return totalPredictions > 0 ? (correctPredictions / totalPredictions) * 100 : 0;
   };


### PR DESCRIPTION
This commit fixes an issue where the prediction accuracy was not being calculated correctly. The fix involves removing the hardcoded 99% and implementing the correct logic to calculate the accuracy.