### PR TITLE
fix: Set region dynamically for stock suggestions

### DIFF
--- a/src/components/StockChartAnalyzer.js
+++ b/src/components/StockChartAnalyzer.js
@@ -71,7 +71,9 @@ function StockChartAnalyzer() {
     const handleInputChange = async (value) => {
         setStockSymbol(value);
         if (value.length >= 1) {
-            const suggestions = await fetchStockSuggestions(value);
+            const isIndianStock = value.toLowerCase().includes('.ns') || ['tcs', 'reliance', 'hdfc', 'infy', 'jiofin'].some(term => value.toLowerCase().includes(term));
+            const region = isIndianStock ? 'IN' : 'US';
+            const suggestions = await fetchStockSuggestions(value, region);
             setFilteredSuggestions(suggestions);
             setShowSuggestions(true);
             setSelectedSuggestionIndex(-1);

--- a/src/services/financialService.js
+++ b/src/services/financialService.js
@@ -109,11 +109,11 @@ export const fetchFinancialDataForProsCons = async (symbol) => {
     return fetchedProsConsData;
   };
 
-export const fetchStockSuggestions = async (query) => {
+export const fetchStockSuggestions = async (query, region = 'US') => {
     if (!query) return [];
     try {
         const proxyUrl = 'https://api.allorigins.win/raw?url=';
-        const yahooUrl = encodeURIComponent(`https://query1.finance.yahoo.com/v1/finance/search?q=${query}&lang=en-US&region=US&quotesCount=6&newsCount=0`);
+        const yahooUrl = encodeURIComponent(`https://query1.finance.yahoo.com/v1/finance/search?q=${query}&lang=en-US&region=${region}&quotesCount=6&newsCount=0`);
         const response = await fetch(proxyUrl + yahooUrl);
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
This commit fixes an issue where the Yahoo Finance API was always returning US as the country for all stocks.

- The `fetchStockSuggestions` function in `src/services/financialService.js` is modified to accept a `region` parameter.
- The `handleInputChange` function in `src/components/StockChartAnalyzer.js` is modified to detect if you are searching for an Indian stock and pass the appropriate region to the `fetchStockSuggestions` function.