### PR TITLE
fix: Use exchange to determine stock market region

### DIFF
--- a/src/services/financialService.js
+++ b/src/services/financialService.js
@@ -123,7 +123,7 @@ export const fetchStockSuggestions = async (query, region = 'US') => {
             return data.quotes.map(quote => ({
                 symbol: quote.symbol,
                 name: quote.longname || quote.shortname,
-                market: quote.exhange || 'US',
+                market: quote.exchange === 'NSI' || quote.exchange === 'BSE' ? 'India' : 'US',
                 sector: quote.sector || 'N/A'
             }));
         }


### PR DESCRIPTION
This commit fixes an issue where the stock market region was not being correctly identified. The `market` property from the Yahoo Finance API was unreliable.

This change modifies the `fetchStockSuggestions` function to use the `exchange` property to determine the market. If the exchange is 'NSI' or 'BSE', the market is set to 'India', otherwise it defaults to 'US'.